### PR TITLE
add tr_S attribute for use in GWR

### DIFF
--- a/spglm/glm.py
+++ b/spglm/glm.py
@@ -218,6 +218,7 @@ class GLMResults(LikelihoodModelResults):
                         McFadden's pseudo R2  (coefficient of determination)
         adj_pseudoR2  : float
                         adjusted McFadden's pseudo R2
+        tr_S          : trace of the hat matrix S
         resid_response          : array
                                   response residuals; defined as y-mu
         resid_pearson           : array
@@ -382,3 +383,9 @@ class GLMResults(LikelihoodModelResults):
     def adj_pseudoR2(self):
         return 1 - ((self.llf-self.k)/self.llnull)
 
+    @cache_readonly
+    def tr_S(self):
+        xtx_inv = np.linalg.inv(np.dot(self.X.T, self.X))
+        xtx_inv_xt = np.dot(xtx_inv, self.X.T)
+        S = np.dot(self.X, xtx_inv_xt)
+        return np.trace(S)

--- a/spglm/tests/test_glm.py
+++ b/spglm/tests/test_glm.py
@@ -154,6 +154,7 @@ class TestGaussian(unittest.TestCase):
                 38.43622447,  38.43622447,  38.43622447,  38.43622447,  38.43622447])
         self.assertAlmostEqual(results.D2, .349514377851)
         self.assertAlmostEqual(results.adj_D2, 0.32123239427957673)
+        self.assertAlmostEqual(results.tr_S, 3.0)
 
 class TestPoisson(unittest.TestCase):
 


### PR DESCRIPTION
This PR adda anew attribute to the GLMResults class that is the effective number of parameters (trace of hat matrix) for use in computing diagnostics to compare ols to GWR/MGWR.