### PR TITLE
fix check_constant returns

### DIFF
--- a/spglm/glm.py
+++ b/spglm/glm.py
@@ -89,7 +89,7 @@ class GLM(RegressionPropsY):
         USER.check_y(y, self.n)
         self.y = y
         if constant:
-            self.X = USER.check_constant(X)
+            self.X,_,_ = USER.check_constant(X)
         else:
             self.X = X
         self.family = family


### PR DESCRIPTION
The returned value of the github version of `spreg`'s [`check_constant`](https://github.com/pysal/spreg/blob/master/spreg/user_output.py#L582) function is [a tuple whose first element is the matrix with independent variables plus constant]( https://github.com/pysal/spreg/blob/master/spreg/user_output.py#L638)

CI against the pypi versions failed, but it succeeds against the github master branch.