### PR TITLE
Remove np.float due to deprecation error

### DIFF
--- a/spglm/iwls.py
+++ b/spglm/iwls.py
@@ -108,7 +108,7 @@ def iwls(y, x, family, offset, y_fix,
     diff = 1.0e6
 
     if ini_betas is None:
-        betas = np.zeros((x.shape[1], 1), np.float)
+        betas = np.zeros((x.shape[1], 1))
     else:
         betas = ini_betas
 


### PR DESCRIPTION
At [this line](https://github.com/pysal/spglm/blob/7b00f42eaee795142e90aba2435d4ce34e8613fe/spglm/iwls.py#L111), Numpy 1.24 will raise an error for `np.float`, which is deprecated. This causes error in downstream `mgwr`'s [auto testing](https://github.com/pysal/mgwr/actions/runs/3879271830/jobs/6616291423#step:7:2279).

[Numpy 1.24 release note](https://numpy.org/devdocs/release/1.24.0-notes.html#expired-deprecations)