### PR TITLE
remove special def for `np.linalg.matrix_rank`

### DIFF
--- a/spglm/utils.py
+++ b/spglm/utils.py
@@ -3,6 +3,8 @@ import warnings
 
 import numpy as np
 
+np_matrix_rank = np.linalg.matrix_rank
+
 
 def _bit_length_26(x):
     if x == 0:
@@ -11,151 +13,6 @@ def _bit_length_26(x):
         return 1
     else:
         return len(bin(x)) - 2
-
-
-try:
-    from numpy.lib._version import NumpyVersion
-except ImportError:
-    import re
-
-    ######################################################################
-    # TODO - remove GH#39
-    string_types = basestring  # noqa: F821 - `basestring` not defined - should remove
-    ######################################################################
-
-    class NumpyVersion:
-        """Parse and compare numpy version strings.
-        Numpy has the following versioning scheme (numbers given are examples; they
-        can be >9) in principle):
-        - Released version: '1.8.0', '1.8.1', etc.
-        - Alpha: '1.8.0a1', '1.8.0a2', etc.
-        - Beta: '1.8.0b1', '1.8.0b2', etc.
-        - Release candidates: '1.8.0rc1', '1.8.0rc2', etc.
-        - Development versions: '1.8.0.dev-f1234afa' (git commit hash appended)
-        - Development versions after a1: '1.8.0a1.dev-f1234afa',
-                                        '1.8.0b2.dev-f1234afa',
-                                        '1.8.1rc1.dev-f1234afa', etc.
-        - Development versions (no git hash available): '1.8.0.dev-Unknown'
-        Comparing needs to be done against a valid version string or other
-        `NumpyVersion` instance.
-        Parameters
-        ----------
-        vstring : str
-            Numpy version string (``np.__version__``).
-        Notes
-        -----
-        All dev versions of the same (pre-)release compare equal.
-        Examples
-        --------
-        >>> from numpy.lib._version import NumpyVersion
-        >>> if NumpyVersion(np.__version__) < '1.7.0':
-        ...     print('skip')
-        skip
-        >>> NumpyVersion('1.7')  # raises ValueError, add ".0"
-        """
-
-        def __init__(self, vstring):
-            self.vstring = vstring
-            ver_main = re.match(r"\d[.]\d+[.]\d+", vstring)
-            if not ver_main:
-                raise ValueError("Not a valid numpy version string")
-
-            self.version = ver_main.group()
-            self.major, self.minor, self.bugfix = (
-                int(x) for x in self.version.split(".")
-            )
-            if len(vstring) == ver_main.end():
-                self.pre_release = "final"
-            else:
-                alpha = re.match(r"a\d", vstring[ver_main.end() :])
-                beta = re.match(r"b\d", vstring[ver_main.end() :])
-                rc = re.match(r"rc\d", vstring[ver_main.end() :])
-                pre_rel = [m for m in [alpha, beta, rc] if m is not None]
-                if pre_rel:
-                    self.pre_release = pre_rel[0].group()
-                else:
-                    self.pre_release = ""
-
-            self.is_devversion = bool(re.search(r".dev-", vstring))
-
-        def _compare_version(self, other):
-            """Compare major.minor.bugfix"""
-            if self.major == other.major:
-                if self.minor == other.minor:
-                    if self.bugfix == other.bugfix:
-                        vercmp = 0
-                    elif self.bugfix > other.bugfix:
-                        vercmp = 1
-                    else:
-                        vercmp = -1
-                elif self.minor > other.minor:
-                    vercmp = 1
-                else:
-                    vercmp = -1
-            elif self.major > other.major:
-                vercmp = 1
-            else:
-                vercmp = -1
-
-            return vercmp
-
-        def _compare_pre_release(self, other):
-            """Compare alpha/beta/rc/final."""
-            if self.pre_release == other.pre_release:
-                vercmp = 0
-            elif self.pre_release == "final":
-                vercmp = 1
-            elif other.pre_release == "final":
-                vercmp = -1
-            elif self.pre_release > other.pre_release:
-                vercmp = 1
-            else:
-                vercmp = -1
-
-            return vercmp
-
-        def _compare(self, other):
-            if not isinstance(other, (string_types, NumpyVersion)):
-                raise ValueError("Invalid object to compare with NumpyVersion.")
-
-            if isinstance(other, string_types):
-                other = NumpyVersion(other)
-
-            vercmp = self._compare_version(other)
-            if vercmp == 0:
-                # Same x.y.z version, check for alpha/beta/rc
-                vercmp = self._compare_pre_release(other)
-                if vercmp == 0:
-                    # Same version and same pre-release, check if dev version
-                    if self.is_devversion is other.is_devversion:
-                        vercmp = 0
-                    elif self.is_devversion:
-                        vercmp = -1
-                    else:
-                        vercmp = 1
-
-            return vercmp
-
-        def __lt__(self, other):
-            return self._compare(other) < 0
-
-        def __le__(self, other):
-            return self._compare(other) <= 0
-
-        def __eq__(self, other):
-            return self._compare(other) == 0
-
-        def __ne__(self, other):
-            return self._compare(other) != 0
-
-        def __gt__(self, other):
-            return self._compare(other) > 0
-
-        def __ge__(self, other):
-            return self._compare(other) >= 0
-
-        def __repr(self):
-            return f"NumpyVersion({self.vstring})"
 
 
 class ResettableCache(dict):
@@ -189,15 +46,6 @@ class ResettableCache(dict):
         dict.__delitem__(self, key)
         for mustreset in self._resetdict.get(key, []):
             del self[mustreset]
-
-
-#    def __getstate__(self):
-#        print('pickling wrapper', self.__dict__)
-#        return self.__dict__
-#
-#    def __setstate__(self, dict_):
-#        print('unpickling wrapper', dict_)
-#        self.__dict__.update(dict_)
 
 
 resettable_cache = ResettableCache
@@ -249,89 +97,6 @@ def _next_regular(target):
     if p5 < match:
         match = p5
     return match
-
-
-if NumpyVersion(np.__version__) >= "1.7.1":
-    np_matrix_rank = np.linalg.matrix_rank
-else:
-
-    def np_matrix_rank(M, tol=None):  # noqa: N803 - Argument name should be lowercase
-        """
-        Return matrix rank of array using SVD method
-        Rank of the array is the number of SVD singular values of the array that are
-        greater than `tol`.
-        Parameters
-        ----------
-        M : {(M,), (M, N)} array_like
-            array of <=2 dimensions
-        tol : {None, float}, optional
-        threshold below which SVD values are considered zero. If `tol` is
-        None, and ``S`` is an array with singular values for `M`, and
-        ``eps`` is the epsilon value for datatype of ``S``, then `tol` is
-        set to ``S.max() * max(M.shape) * eps``.
-        Notes
-        -----
-        The default threshold to detect rank deficiency is a test on the magnitude
-        of the singular values of `M`.  By default, we identify singular values less
-        than ``S.max() * max(M.shape) * eps`` as indicating rank deficiency (with
-        the symbols defined above). This is the algorithm MATLAB uses [1].  It also
-        appears in *Numerical recipes* in the discussion of SVD solutions for linear
-        least squares [2].
-        This default threshold is designed to detect rank deficiency accounting for
-        the numerical errors of the SVD computation.  Imagine that there is a column
-        in `M` that is an exact (in floating point) linear combination of other
-        columns in `M`. Computing the SVD on `M` will not produce a singular value
-        exactly equal to 0 in general: any difference of the smallest SVD value from
-        0 will be caused by numerical imprecision in the calculation of the SVD.
-        Our threshold for small SVD values takes this numerical imprecision into
-        account, and the default threshold will detect such numerical rank
-        deficiency.  The threshold may declare a matrix `M` rank deficient even if
-        the linear combination of some columns of `M` is not exactly equal to
-        another column of `M` but only numerically very close to another column of
-        `M`.
-        We chose our default threshold because it is in wide use.  Other thresholds
-        are possible.  For example, elsewhere in the 2007 edition of *Numerical
-        recipes* there is an alternative threshold of ``S.max() *
-        np.finfo(M.dtype).eps / 2. * np.sqrt(m + n + 1.)``. The authors describe
-        this threshold as being based on "expected roundoff error" (p 71).
-        The thresholds above deal with floating point roundoff error in the
-        calculation of the SVD.  However, you may have more information about the
-        sources of error in `M` that would make you consider other tolerance values
-        to detect *effective* rank deficiency.  The most useful measure of the
-        tolerance depends on the operations you intend to use on your matrix.  For
-        example, if your data come from uncertain measurements with uncertainties
-        greater than floating point epsilon, choosing a tolerance near that
-        uncertainty may be preferable.  The tolerance may be absolute if the
-        uncertainties are absolute rather than relative.
-        References
-        ----------
-        .. [1] MATLAB reference documention, "Rank"
-            http://www.mathworks.com/help/techdoc/ref/rank.html
-        .. [2] W. H. Press, S. A. Teukolsky, W. T. Vetterling and B. P. Flannery,
-            "Numerical Recipes (3rd edition)", Cambridge University Press, 2007,
-            page 795.
-        Examples
-        --------
-        >>> from numpy.linalg import matrix_rank
-        >>> matrix_rank(np.eye(4)) # Full rank matrix
-        4
-        >>> I=np.eye(4); I[-1,-1] = 0. # rank deficient matrix
-        >>> matrix_rank(I)
-        3
-        >>> matrix_rank(np.ones((4,))) # 1 dimension - rank 1 unless all 0
-        1
-        >>> matrix_rank(np.zeros((4,)))
-        0
-        """
-        M = np.asarray(M)
-        if M.ndim > 2:
-            raise TypeError("array should have 2 or fewer dimensions")
-        if M.ndim < 2:
-            return int(not all(M == 0))
-        S = np.linalg.svd(M, compute_uv=False)
-        if tol is None:
-            tol = S.max() * max(M.shape) * np.finfo(S.dtype).eps
-        return np.sum(tol < S)
 
 
 class CacheWriteWarning(UserWarning):


### PR DESCRIPTION
* remove special def for `np.linalg.matrix_rank`
* resolves #38

-------------------

Looks like `np_matrix_rank` is actually not being used anywhere in the ecosystem. Should we remove? If so, should we add a `FutureWarning` that it will be removed or just pull the plug?

<img width="1008" height="553" alt="Screenshot 2026-04-05 at 4 09 37 PM" src="https://github.com/user-attachments/assets/d380e33f-ece3-4c8b-9426-e9e865ec6f06" />